### PR TITLE
fix non-caps search params

### DIFF
--- a/scripts/BeatmapFile.js
+++ b/scripts/BeatmapFile.js
@@ -497,9 +497,9 @@ export class BeatmapFile {
             } else {
                 const raw = urlParams.get("m") && /[A-Z]+/g.test(urlParams.get("m")) ? urlParams.get("m").match(/.{2}/g) : [];
                 const mods = raw.reduce((arr, mod) => {
-                    if (!["HD", "HR", "DT", "HT", "EZ"].includes(mod)) return arr;
+                    if (!["HD", "HR", "DT", "HT", "EZ"].includes(mod.toUpperCase())) return arr;
                     return [...arr, mod];
-                }, []);
+                }, []).map(e => e.toUpperCase());
 
                 document.querySelector("#HD").disabled = false;
                 document.querySelector("#HR").disabled = false;

--- a/scripts/BeatmapFile.js
+++ b/scripts/BeatmapFile.js
@@ -495,11 +495,13 @@ export class BeatmapFile {
 
                 calculateCurrentSR([Game.MODS.HR, Game.MODS.EZ, Game.MODS.DT, Game.MODS.HT]);
             } else {
-                const raw = urlParams.get("m") && /[A-Z]+/g.test(urlParams.get("m")) ? urlParams.get("m").match(/.{2}/g) : [];
-                const mods = raw.reduce((arr, mod) => {
-                    if (!["HD", "HR", "DT", "HT", "EZ"].includes(mod.toUpperCase())) return arr;
-                    return [...arr, mod];
-                }, []).map(e => e.toUpperCase());
+                const raw = urlParams.get("m") && /[A-Za-z]+/g.test(urlParams.get("m")) ? urlParams.get("m").match(/.{2}/g) : [];
+                const mods = raw
+                    .reduce((arr, mod) => {
+                        if (!["HD", "HR", "DT", "HT", "EZ"].includes(mod.toUpperCase())) return arr;
+                        return [...arr, mod.toUpperCase()];
+                    }, [])
+                    .map((e) => e.toUpperCase());
 
                 document.querySelector("#HD").disabled = false;
                 document.querySelector("#HR").disabled = false;


### PR DESCRIPTION
Likely to fix #43 .

Just add minimal code to transform all mods params to uppercase. 
like `https://preview.tryz.id.vn/?b=4112627&m=hDhrDTEf` will recognize `HD`, `HR`, and `DT` 

*This code has not been tested in the viewer yet, just quick edit.*