### PR TITLE
Speed up loading times by loading things in parallel

### DIFF
--- a/scripts/BackgroundLoader.js
+++ b/scripts/BackgroundLoader.js
@@ -1,0 +1,29 @@
+/**
+ * Allows starting a loading process in the background & await the load to finish before
+ * using the object
+ * @template T
+ */
+export class BackgroundLoader {
+    /**
+     * @param {() => Promise<T>} loadFn
+     * @param {boolean} [loadImmediately=false] whether to start loading immediately
+     */
+    constructor(loadFn, loadImmediately = false) {
+        this.loadFn = loadFn
+        if (loadImmediately)
+            this.load().then()
+    }
+
+    /**
+     * @returns {Promise<T>}
+     */
+    async load() {
+        this.loadPromise ??= this.loadFn()
+
+        return this.loadPromise
+    }
+
+    loadInBackground() {
+        this.load().then()
+    }
+}

--- a/scripts/Cursor.js
+++ b/scripts/Cursor.js
@@ -1,6 +1,7 @@
 import { Game } from "./Game.js";
 import { ScoreParser } from "./ScoreParser.js";
 import * as PIXI from "pixi.js";
+import {loadParallel} from "./Utils.js";
 
 export class Cursor {
     obj;
@@ -10,13 +11,15 @@ export class Cursor {
     async init() {
         const container = new PIXI.Container();
 
-        const cursorTexture = await PIXI.Assets.load("/static/cursor.png");
+        const [cursorTexture, trailTexture] = await Promise.all([
+            PIXI.Assets.load("/static/cursor.png"),
+            PIXI.Assets.load("/static/cursortrail.png")
+        ]);
         this.cursor = PIXI.Sprite.from(cursorTexture);
         this.cursor.anchor.set(0.5);
         this.cursor.width = (128 * (1024 / 640)) / (Game.WIDTH / 512);
         this.cursor.height = (128 * (1024 / 640)) / (Game.WIDTH / 512);
 
-        const trailTexture = await PIXI.Assets.load("/static/cursortrail.png");
         const trailList = [...Array(10).keys()].map(() => PIXI.Sprite.from(trailTexture));
         this.trailList = trailList;
 

--- a/scripts/Database.js
+++ b/scripts/Database.js
@@ -126,6 +126,9 @@ export class Database {
         })
     }
 
+    static skinSetupPromises = {}
+
+
     static async getDefaults(type, value, skin) {
         return new Promise(async (resolve, reject) => {
             let transaction = Database.db.transaction("defaultSkins", "readwrite");
@@ -133,7 +136,9 @@ export class Database {
             const allKeys = await this.getAllDefaultKeys();
 
             if (!allKeys.includes(skin)) {
-                await Database.setupSkins(skin);
+                this.skinSetupPromises[skin] ??= Database.setupSkins(skin);
+
+                await this.skinSetupPromises[skin];
             }
 
             transaction = Database.db.transaction("defaultSkins", "readwrite");

--- a/scripts/FFmpeg.js
+++ b/scripts/FFmpeg.js
@@ -1,16 +1,11 @@
 import { FFmpeg } from "@ffmpeg/ffmpeg";
 import { toBlobURL, fetchFile } from "@ffmpeg/util";
+import { BackgroundLoader } from "./BackgroundLoader.js";
 
 export class Transcoder {
     static ffmpeg = new FFmpeg();
 
-    static async load() {
-        if (navigator.userAgent.match(/webOS/i) || navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPad/i)) {
-            return;
-        }
-
-        const baseURL = "https://unpkg.com/@ffmpeg/core@0.12.6/dist/esm";
-
+    static {
         // this.ffmpeg.on("log", ({ message }) => {
         //     console.log(message);
         // });
@@ -18,15 +13,35 @@ export class Transcoder {
         this.ffmpeg.on("progress", ({ progress, time }) => {
             document.querySelector("#loadingText").textContent = `Transcoding video to mp4 using FFmpeg: ${(progress * 100).toFixed(2)}%`;
         });
+    }
+    static loader = new BackgroundLoader(async () => {
+        if (navigator.userAgent.match(/webOS/i) || navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPad/i)) {
+            return;
+        }
 
-        document.querySelector("#loadingText").textContent = `Loading FFmpeg\nMight take a while on first load.`;
+        const baseURL = "https://unpkg.com/@ffmpeg/core@0.12.6/dist/esm";
+
+        // fixme: disabled this message for now as it doesn't make that much sense now that it loads in the background,
+        //  perhaps it should only show when ensureLoaded is called?
+        // document.querySelector("#loadingText").textContent = `Loading FFmpeg\nMight take a while on first load.`;
         await this.ffmpeg.load({
             coreURL: await toBlobURL(`${baseURL}/ffmpeg-core.js`, "text/javascript"),
             wasmURL: await toBlobURL(`${baseURL}/ffmpeg-core.wasm`, "application/wasm"),
         });
+    })
+
+
+    static loadInBackground() {
+        this.loader.loadInBackground()
+    }
+
+    static async ensureLoaded() {
+        return this.loader.load()
     }
 
     static async transcode({ blob, ext }) {
+        await this.ensureLoaded();
+
         if (navigator.userAgent.match(/webOS/i) || navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPad/i)) {
             return URL.createObjectURL(blob);
         }

--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -894,7 +894,7 @@ export class Game {
 		HitSample.masterGainNode.gain.value = Game.HS_VOL * Game.MASTER_VOL;
 		HitSample.masterGainNode.connect(Game.AUDIO_CTX.destination);
 
-		await Transcoder.load();
+		Transcoder.loadInBackground();
 
 		Game.INIT = true;
 		Game.WORKER.onmessage = (event) => {

--- a/scripts/Texture.js
+++ b/scripts/Texture.js
@@ -1,6 +1,7 @@
 import { Game } from "./Game.js";
 import { Database } from "./Database.js";
 import * as PIXI from "pixi.js";
+import {loadParallel} from "./Utils.js";
 
 export class Texture {
     static SELECTED;
@@ -191,103 +192,125 @@ export class Texture {
     }
 
     static async generateDefaultTextures() {
-        Texture.SELECTED = {
-            // texture: PIXI.Texture.from("/static/legacy/hitcircleselect@2x.png"),
-            texture: await PIXI.Assets.load(await Database.getDefaults("base64s", "hitcircleselect@2x", "legacy")),
-            isHD: true,
-        };
-        Texture.SELECTED_ARGON = {
-            texture: await Texture.createTexture("SELECTED_HIT_CIRCLE"),
-            isHD: false,
-        }
-        Texture.FOLLOWPOINT = {
-            texture: await PIXI.Assets.load("/static/followpoint@2x.png"),
-            isHD: true
-        }
-        Texture.ARGON.HIT_CIRCLE = {
-            texture: await Texture.createTexture("HIT_CIRCLE"),
-            isHD: false,
-        };
-        Texture.ARGON.HIT_CIRCLE_OVERLAY = {
-            texture: await Texture.createTexture("HIT_CIRCLE_OVERLAY"),
-            isHD: false,
-        };
-        Texture.ARGON.SLIDER_B = {
-            ring: {
-                texture: await Texture.createTexture("SLIDER_BALL"),
-                isHD: false,
-            },
-            arrow: {
-                texture: await PIXI.Assets.load("/static/arrow.png"),
-                isHD: false,
-            },
-            gradient: {
-                texture: await Texture.createTexture("SLIDER_BALL_BG"),
-                isHD: false,
-            },
-        };
-        Texture.ARGON.REVERSE_ARROW = {
-            arrow: {
-                // texture: PIXI.Texture.from("/static/argon/reversearrow@2x.png"),
-                texture: await PIXI.Assets.load(await Database.getDefaults("base64s", "reversearrow@2x", "argon")),
+        await loadParallel((loadAsync) => {
+            loadAsync(async () => Texture.SELECTED = {
+                // texture: PIXI.Texture.from("/static/legacy/hitcircleselect@2x.png"),
+                texture: await PIXI.Assets.load(await Database.getDefaults("base64s", "hitcircleselect@2x", "legacy")),
                 isHD: true,
-            },
-            ring: {
-                // texture: PIXI.Texture.from("/static/argon/repeat-edge-piece.png"),
-                texture: await PIXI.Assets.load(await Database.getDefaults("base64s", "repeat-edge-piece", "argon")),
+            })
+            loadAsync(async () => Texture.SELECTED_ARGON = {
+                texture: await Texture.createTexture("SELECTED_HIT_CIRCLE"),
                 isHD: false,
-            },
-        };
-        Texture.ARGON.SLIDER_FOLLOW_CIRCLE = {
-            texture: await Texture.createTexture("SLIDER_FOLLOW_CIRCLE"),
-            isHD: false,
-        };
-        Texture.ARGON.APPROACH_CIRCLE = {
-            // texture: PIXI.Texture.from("/static/argon/approachcircle@2x.png"),
-            texture: await PIXI.Assets.load(await Database.getDefaults("base64s", "approachcircle@2x", "argon")),
-            isHD: true,
-        };
-        Texture.ARGON.DEFAULTS = [];
-        for (const idx in [...Array(10)].fill(null, 0, 10)) {
-            Texture.ARGON.DEFAULTS.push({
-                // texture: PIXI.Texture.from(`static/argon/default-${idx}@2x.png`),
-                texture: await PIXI.Assets.load(await Database.getDefaults("base64s", `default-${idx}@2x`, "argon")),
+            });
+            loadAsync(async () => Texture.FOLLOWPOINT = {
+                texture: await PIXI.Assets.load("/static/followpoint@2x.png"),
+                isHD: true
+            });
+            loadAsync(async () => Texture.ARGON.HIT_CIRCLE = {
+                texture: await Texture.createTexture("HIT_CIRCLE"),
+                isHD: false,
+            });
+            loadAsync(async () => Texture.ARGON.HIT_CIRCLE_OVERLAY = {
+                texture: await Texture.createTexture("HIT_CIRCLE_OVERLAY"),
+                isHD: false,
+            });
+            loadAsync(async () => {
+                const [ring, arrow, gradient] = await Promise.all([
+                    Texture.createTexture("SLIDER_BALL"),
+                    PIXI.Assets.load("/static/arrow.png"),
+                    Texture.createTexture("SLIDER_BALL_BG")
+                ])
+
+                Texture.ARGON.SLIDER_B = {
+                    ring: {
+                        texture: ring,
+                        isHD: false,
+                    },
+                    arrow: {
+                        texture: arrow,
+                        isHD: false,
+                    },
+                    gradient: {
+                        texture: gradient,
+                        isHD: false,
+                    },
+                }
+            })
+            loadAsync(async () => {
+                const [arrow, ring] = await Promise.all([
+                    Database.getDefaults("base64s", "reversearrow@2x", "argon").then(source => PIXI.Assets.load(source)),
+                    Database.getDefaults("base64s", "repeat-edge-piece", "argon").then(source => PIXI.Assets.load(source))
+                ])
+
+                Texture.ARGON.REVERSE_ARROW = {
+                    arrow: {
+                        // texture: PIXI.Texture.from("/static/argon/reversearrow@2x.png"),
+                        texture: arrow,
+                        isHD: true,
+                    },
+                    ring: {
+                        // texture: PIXI.Texture.from("/static/argon/repeat-edge-piece.png"),
+                        texture: ring,
+                        isHD: false,
+                    },
+                };
+            })
+            loadAsync(async () => Texture.ARGON.SLIDER_FOLLOW_CIRCLE = {
+                texture: await Texture.createTexture("SLIDER_FOLLOW_CIRCLE"),
+                isHD: false,
+            });
+            loadAsync(async () => Texture.ARGON.APPROACH_CIRCLE = {
+                // texture: PIXI.Texture.from("/static/argon/approachcircle@2x.png"),
+                texture: await PIXI.Assets.load(await Database.getDefaults("base64s", "approachcircle@2x", "argon")),
                 isHD: true,
             });
-        }
-        Texture.ARGON.GLOW = {
-            texture: await Texture.createTexture("GLOW"),
-            isHD: false
-        }
+            Texture.ARGON.DEFAULTS = [];
+            for (const idx in [...Array(10)].fill(null, 0, 10)) {
+                loadAsync(async () => Texture.ARGON.DEFAULTS.push({
+                    // texture: PIXI.Texture.from(`static/argon/default-${idx}@2x.png`),
+                    texture: await PIXI.Assets.load(await Database.getDefaults("base64s", `default-${idx}@2x`, "argon")),
+                    isHD: true,
+                }));
+            }
+            loadAsync(async () => Texture.ARGON.GLOW = {
+                texture: await Texture.createTexture("GLOW"),
+                isHD: false
+            })
 
-        await Texture.updateTextureFor("HIT_CIRCLE");
-        await Texture.updateTextureFor("HIT_CIRCLE_OVERLAY");
-        await Texture.updateTextureFor("SLIDER_B");
-        await Texture.updateTextureFor("SLIDER_FOLLOW_CIRCLE");
-        await Texture.updateTextureFor("REVERSE_ARROW");
-        await Texture.updateTextureFor("APPROACH_CIRCLE");
+            const updateKeys = [
+                "HIT_CIRCLE",
+                "HIT_CIRCLE_OVERLAY",
+                "SLIDER_B",
+                "SLIDER_FOLLOW_CIRCLE",
+                "REVERSE_ARROW",
+                "APPROACH_CIRCLE",
+            ]
 
-        const LEGACY_NUM = [];
-        for (const idx in [...Array(10)].fill(null, 0, 10)) {
-            LEGACY_NUM.push({
-                // texture: PIXI.Texture.from(`static/argon/default-${idx}@2x.png`),
-                base64: await Database.getDefaults("base64s", `default-${idx}@2x`, "legacy"),
+            for (const key of updateKeys)
+                loadAsync(() => Texture.updateTextureFor(key))
+
+            const LEGACY_NUM = [];
+            for (const idx in [...Array(10)].fill(null, 0, 10)) {
+                loadAsync(async () => LEGACY_NUM.push({
+                    // texture: PIXI.Texture.from(`static/argon/default-${idx}@2x.png`),
+                    base64: await Database.getDefaults("base64s", `default-${idx}@2x`, "legacy"),
+                    isHD: true,
+                }));
+            }
+
+            // console.log(LEGACY_NUM);
+            loadAsync(() => Texture.updateNumberTextures(LEGACY_NUM))
+
+            loadAsync(async () => Texture.BALL_SPEC = {
+                texture: await PIXI.Assets.load("static/sliderb-spec@2x.png"),
                 isHD: true,
-            });
-        }
+            })
 
-        // console.log(LEGACY_NUM);
-        await Texture.updateNumberTextures(LEGACY_NUM);
-        
-        Texture.BALL_SPEC = {
-            texture: await PIXI.Assets.load("static/sliderb-spec@2x.png"),
-            isHD: true,
-        }
-        
-        Texture.BALL_ND = {
-            texture: await PIXI.Assets.load("static/sliderb-nd@2x.png"),
-            isHD: true,
-        }
+            loadAsync(async () => Texture.BALL_ND = {
+                texture: await PIXI.Assets.load("static/sliderb-nd@2x.png"),
+                isHD: true,
+            })
+        })
     }
 
     static async updateNumberTextures(arr, forIdx) {

--- a/scripts/Texture.js
+++ b/scripts/Texture.js
@@ -264,14 +264,16 @@ export class Texture {
                 texture: await PIXI.Assets.load(await Database.getDefaults("base64s", "approachcircle@2x", "argon")),
                 isHD: true,
             });
-            Texture.ARGON.DEFAULTS = [];
-            for (const idx in [...Array(10)].fill(null, 0, 10)) {
-                loadAsync(async () => Texture.ARGON.DEFAULTS.push({
-                    // texture: PIXI.Texture.from(`static/argon/default-${idx}@2x.png`),
-                    texture: await PIXI.Assets.load(await Database.getDefaults("base64s", `default-${idx}@2x`, "argon")),
-                    isHD: true,
+            loadAsync(async () => {
+                Texture.ARGON.DEFAULTS = await Promise.all(Array.from({ length: 10}).map(async (_, idx) => {
+                    return {
+                        // texture: PIXI.Texture.from(`static/argon/default-${idx}@2x.png`),
+                        texture: await PIXI.Assets.load(await Database.getDefaults("base64s", `default-${idx}@2x`, "argon")),
+                        isHD: true,
+                    }
                 }));
-            }
+            });
+
             loadAsync(async () => Texture.ARGON.GLOW = {
                 texture: await Texture.createTexture("GLOW"),
                 isHD: false
@@ -289,17 +291,19 @@ export class Texture {
             for (const key of updateKeys)
                 loadAsync(() => Texture.updateTextureFor(key))
 
-            const LEGACY_NUM = [];
-            for (const idx in [...Array(10)].fill(null, 0, 10)) {
-                loadAsync(async () => LEGACY_NUM.push({
-                    // texture: PIXI.Texture.from(`static/argon/default-${idx}@2x.png`),
-                    base64: await Database.getDefaults("base64s", `default-${idx}@2x`, "legacy"),
-                    isHD: true,
-                }));
-            }
+            loadAsync(async () => {
+                const LEGACY_NUM = await Promise.all(
+                    Array.from({length: 10}).map(async (_, idx) => {
+                        return {
+                            // texture: PIXI.Texture.from(`static/argon/default-${idx}@2x.png`),
+                            base64: await Database.getDefaults("base64s", `default-${idx}@2x`, "legacy"),
+                            isHD: true,
+                        }
+                    })
+                );
 
-            // console.log(LEGACY_NUM);
-            loadAsync(() => Texture.updateNumberTextures(LEGACY_NUM))
+                await Texture.updateNumberTextures(LEGACY_NUM)
+            })
 
             loadAsync(async () => Texture.BALL_SPEC = {
                 texture: await PIXI.Assets.load("static/sliderb-spec@2x.png"),

--- a/scripts/User.js
+++ b/scripts/User.js
@@ -1,5 +1,6 @@
 import * as PIXI from "pixi.js";
 import { Game } from "./Game";
+import {loadParallel} from "./Utils.js";
 
 export class User {
     static container = new PIXI.Container();
@@ -28,22 +29,24 @@ export class User {
         this.container.addChild(this.graphics, this.username, this.modsContainer);
         this.container.visible = false;
 
-        for (const mod of [
-            "DoubleTime",
-            "Easy",
-            "Flashlight",
-            "HalfTime",
-            "HardRock",
-            "Hidden",
-            "Nightcore",
-            "NoFail",
-            "Perfect",
-            "ScoreV2",
-            "SpunOut",
-            "SuddenDeath",
-        ]) {
-            this.textures[mod] = await PIXI.Assets.load({ src: `/static/mods/${mod}.png`, loadParser: "loadTextures" });
-        }
+        await loadParallel((loadAsync) => {
+            for (const mod of [
+                "DoubleTime",
+                "Easy",
+                "Flashlight",
+                "HalfTime",
+                "HardRock",
+                "Hidden",
+                "Nightcore",
+                "NoFail",
+                "Perfect",
+                "ScoreV2",
+                "SpunOut",
+                "SuddenDeath",
+            ]) {
+                loadAsync(async () => this.textures[mod] = await PIXI.Assets.load({ src: `/static/mods/${mod}.png`, loadParser: "loadTextures" }));
+            }
+        })
     }
 
     static forceResize() {

--- a/scripts/Utils.js
+++ b/scripts/Utils.js
@@ -563,3 +563,27 @@ export const easeOutElastic = (x) => {
 // https://github.com/Damnae/storybrew/blob/master/common/Animations/EasingFunctions.cs
 export const easeOutElasticHalf = (x) => Math.pow(2, -10 * x) * Math.sin(((0.5 * x - 0.075) * (2 * Math.PI)) / 0.3) + 1;
 export const easeOutElasticQuart = (x) => Math.pow(2, -10 * x) * Math.sin(((0.25 * x - 0.075) * (2 * Math.PI)) / 0.3) + 1;
+
+/**
+ * Allows queueing up several promises in parallel
+ *
+ * @example ```js
+ * await loadParallel((loadAsync) => {
+ *      loadAsync(async () => await someAsyncValue())
+ *      loadAsync(async () => await someOtherAsyncValue())
+ * })
+ * ```
+ *
+ * @param {(fnOrPromise: Promise<any> | (() => Promise<any>)) => void | Promise<void>} loadFn
+ * @returns {Promise<unknown[]>}
+ */
+export async function loadParallel(loadFn) {
+    const loadPromises = []
+
+    const loadAsync = (fnOrPromise) =>
+        loadPromises.push(typeof fnOrPromise === 'function' ? fnOrPromise() : fnOrPromise)
+
+    await loadFn(loadAsync)
+
+    return await Promise.all(loadPromises)
+}

--- a/scripts/Utils.js
+++ b/scripts/Utils.js
@@ -341,26 +341,30 @@ export const loadColorPalette = (bg) => {
 };
 
 export async function loadDefaultSamples() {
-    for (const skin of ["ARGON", "LEGACY"])
-        for (const sampleset of ["normal", "soft", "drum"]) {
-            for (const hs of ["hitnormal", "hitwhistle", "hitfinish", "hitclap", "slidertick", "sliderwhistle", "sliderslide"]) {
-                // console.log(`./static/${skin.toLowerCase()}/${sampleset}-${hs}.wav`);
-                // const res = (
-                //     await axios.get(`/static/${skin.toLowerCase()}/${sampleset}-${hs}.wav`, {
-                //         responseType: "arraybuffer",
-                //     })
-                // ).data;
+    await loadParallel((loadAsync) => {
+        for (const skin of ["ARGON", "LEGACY"])
+            for (const sampleset of ["normal", "soft", "drum"]) {
+                for (const hs of ["hitnormal", "hitwhistle", "hitfinish", "hitclap", "slidertick", "sliderwhistle", "sliderslide"]) {
+                    loadAsync(async () => {
+                        // console.log(`./static/${skin.toLowerCase()}/${sampleset}-${hs}.wav`);
+                        // const res = (
+                        //     await axios.get(`/static/${skin.toLowerCase()}/${sampleset}-${hs}.wav`, {
+                        //         responseType: "arraybuffer",
+                        //     })
+                        // ).data;
 
-                document.querySelector(
-                    "#loadingText"
-                ).innerHTML = `Initializing: Default Samples.\n(${skin}: ${sampleset}-${hs})\nMight take a while on first load.`;
-                const arrBuf = await Database.getDefaults("samples", `${sampleset}-${hs}`, skin.toLowerCase());
-                // console.log(arrBuf);
-                const buffer = await Game.AUDIO_CTX.decodeAudioData(arrBuf);
-                HitSample.SAMPLES[skin][`${sampleset}-${hs}`] = buffer;
-                HitSample.DEFAULT_SAMPLES[skin][`${sampleset}-${hs}`] = buffer;
+                        document.querySelector(
+                            "#loadingText"
+                        ).innerHTML = `Initializing: Default Samples.\n(${skin}: ${sampleset}-${hs})\nMight take a while on first load.`;
+                        const arrBuf = await Database.getDefaults("samples", `${sampleset}-${hs}`, skin.toLowerCase());
+                        // console.log(arrBuf);
+                        const buffer = await Game.AUDIO_CTX.decodeAudioData(arrBuf);
+                        HitSample.SAMPLES[skin][`${sampleset}-${hs}`] = buffer;
+                        HitSample.DEFAULT_SAMPLES[skin][`${sampleset}-${hs}`] = buffer;
+                    });
+                }
             }
-        }
+    })
 }
 
 export async function loadSampleSound(sample, idx, buf) {


### PR DESCRIPTION
I made things load in parallel to speed up the load times for the beatmap viewer.
I tested in chrome with network throttling enabled with the `Fast 4G` preset, results were an improvement from around 40 to 12 seconds on my machine. There's probably even more room for improvement but I feel like this change is big enough as it is already.

I tried to do each individual change in it's own self-contained commit so you should be able to revert individual commits if you don't like a specific part of it.


## List of changes:
- Aded a `loadParallel` helper function which makes it easier to queue up promises in parallel
Can be used like this:
```js
await loadParallel((loadAsync) => {
     loadAsync(async () => await someAsyncValue());
     loadAsync(async () => await someOtherAsyncValue());
     loadAsync(somePromise);
})
```
You can either pass a promise, or a function returning a promise into the loadAsync function. It will run all promises in parallel, and the `loadParallel` method call resolves once every promise has resolved (and returns all queued up items in the order they were added if there is ever a need for that).
- Loading skins' default samples & textures in parallel
- Running all async calls in `refreshSkinDB` in parallel
- Loading FFMPEG in background, this makes use of a `BackgroundLoader` class that I added. It lets you run a promise in the background, and once you want to actually want use it it will wait until the background load has finished.
Usage is:
```js
const loader = new BackgroundLoader(async () => computeAsyncValue())

loader.loadInBackground()

setTimeout(async () => {
  // if already loaded will resolve immediately, otherwise it will wait until the value is loaded until it resolves
  const value = loader.load()  
}, 1000)
```
This way the rest of the app can continue loading while ffmpeg loads in the background and it will only wait for it to finish loading once it's actually needed to transcode a video.
- Loading mod icons in parallel
- Loading play button icons in parallel
- Loading cursor textures in parallel
- Loading the root components of the game in parallel. I tried to be careful here to not mess up the order in which the components get added to the stage, so I am not doing as much in parallel there as I could.

## Comparison (production build, cleared IndexedDB, disabled caching, network throttling with `Fast 4G` preset)

### Before

https://github.com/user-attachments/assets/e2b02b04-8252-408d-b9e3-b6489fe12a84

### After

https://github.com/user-attachments/assets/a99c3616-095d-4c23-b905-afd342637210

